### PR TITLE
Enhancing SFSymbolsPickerForSwiftUI with macOS Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "SFSymbolsPicker",
-    platforms: [.iOS(.v14)],
+    platforms: [.iOS(.v14), .macOS(.v11)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SF Symbols Picker
 
-SFSymbolsPicker is a simple and powerful SwiftUI picker that let you pick Apple's SF Symbols inside your iOS app with an easy binding!
+SFSymbolsPicker is a simple and powerful SwiftUI picker that let you pick Apple's SF Symbols inside your iOS and macOS apps with an easy binding!
 
 ![SF Symbols Picker](./Resources/SFSymbolsPicker.png)
 
@@ -52,6 +52,7 @@ var body: some View {
 
 Required:
 - iOS 14.0 or above
+- macOS 11.0 or above
 - Xcode 12.0 or above
 
 In Xcode go to `File -> Add Package Dependencies...` and paste in the repo's url: `https://github.com/alessiorubicini/SFSymbolsPicker`.

--- a/Sources/SFSymbolsPicker/SearchBar.swift
+++ b/Sources/SFSymbolsPicker/SearchBar.swift
@@ -33,7 +33,11 @@ struct SearchBar: View {
                 .padding(.leading, 10)
                 .padding(.trailing, 15)
                 .foregroundColor(.secondary)
+#if os(iOS)
                 .background(Color(.systemGray6))
+#else
+                .background(Color(.systemGray))
+#endif
                 .cornerRadius(8)
                 .padding(.horizontal, 5)
                 .onTapGesture {

--- a/Sources/SFSymbolsPicker/SymbolsPicker.swift
+++ b/Sources/SFSymbolsPicker/SymbolsPicker.swift
@@ -54,7 +54,9 @@ public struct SymbolsPicker: View {
                     }
                 }
                 .navigationTitle(vm.title)
+#if os(iOS)
                 .navigationBarTitleDisplayMode(.inline)
+#endif
                 .toolbar {
                     ToolbarItem(placement: .confirmationAction) {
                         Button {


### PR DESCRIPTION
I've extended the functionality of SFSymbolsPickerForSwiftUI by adding support for macOS 11.0 and above. This update enables developers to utilize this tool within macOS applications, broadening its applicability and utility. 

I'd like to express my gratitude for the original work on this project, which inspired me to contribute. Looking forward to your feedback and hoping this enhancement can be integrated into the main branch for everyone to benefit from.

The `Resources/SFSymbolsPicker.png` image needs to be updated.