### PR TITLE
Add SFSymbolsPicker Import in UsageExample.swift

### DIFF
--- a/Sources/SFSymbolsPicker/UsageExample.swift
+++ b/Sources/SFSymbolsPicker/UsageExample.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import SFSymbolsPicker
 
 struct UsageExample: View {
     


### PR DESCRIPTION
Hey,

thanks a lot of the library.

It seems the example is missing `import SFSymbolsPicker`.